### PR TITLE
Fixed dead link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ State of the project :
 Documentation
 #############
 
-You will find all documentation needed on https://lisa-project.readthedocs.org/en/latest/index.html
+You will find all documentation needed on https://lisa.readthedocs.org/en/latest/index.html
 
 Overview
 ########


### PR DESCRIPTION
Changed "lisa-project" to "lisa" in url
